### PR TITLE
fix(desktop): add the version field back to tauri.conf.json file

### DIFF
--- a/platform/desktop/tauri.conf.json
+++ b/platform/desktop/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "gqlx",
+  "version": "0.1.0-1",
   "identifier": "dev.gqlx.app",
   "build": {
     "devUrl": "http://localhost:4200",


### PR DESCRIPTION
The windows build (which uses wix) doesn't accept pre-release version tags. We avoid this problem by using a numeric version tag only.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
